### PR TITLE
Added unlock all awards

### DIFF
--- a/WasabiWords.lua
+++ b/WasabiWords.lua
@@ -520,3 +520,17 @@ wasabi_words:add_button("ShinyWasabi", function() --Original script by ShinyWasa
         gui.show_message('WasabiWordsTM', 'Clichés Subverted')
     end)
 end)
+
+wasabi_words:add_sameline()
+
+wasabi_words:add_button("Unlock All Awards", function()
+    script.run_in_fiber(function (script)
+		for i = 0, 151 do
+			STATS.STAT_SET_INT(STATS.GET_STAT_HASH_FOR_CHARACTER_STAT_(8, i, stats.get_character_index()), 2147483647, true) -- should be fine?
+		end
+		for i = 0, 167 do
+			STATS.STAT_SET_BOOL(STATS.GET_STAT_HASH_FOR_CHARACTER_STAT_(10, i, stats.get_character_index()), true, true)
+		end
+        gui.show_message('WasabiWordsTM', 'All Awards Unlocked')
+    end)
+end)


### PR DESCRIPTION
I added a separate button to unlock all awards using the GET_STAT_HASH_FOR_CHARACTER_STAT native, instead of hundreds of lines of code. I didn't include the float one (AWD_TEMPAWARDFLOAT) because it doesn't seem to be an actual award, and MPPLY ones already included in the first button.