### PR TITLE
Bypass G9EC Lock Hashes

### DIFF
--- a/WasabiWords.lua
+++ b/WasabiWords.lua
@@ -1,3 +1,13 @@
+local is_content_item_locked = memory.scan_pattern("89 54 24 ? 48 83 EC ? 85 D2")
+
+memory.dynamic_hook("is_content_item_locked", "bool", { "int", "int" }, is_content_item_locked,
+function(ret_val, this, hash)
+    ret_val:set(false)
+    return false
+end,
+function(ret_val, this, hash)
+end)
+
 function unlock_packed_bools(from, to)
     for i = from, to do
         stats.set_packed_stat_bool(i, true)


### PR DESCRIPTION
This will hook the `IS_CONTENT_ITEM_LOCKED` native and make it always return false, which bypasses the below check:
```c
FILES::GET_SHOP_PED_PROP(iVar2, &Var20);
if (FILES::IS_CONTENT_ITEM_LOCKED(Var20.f_0) || func_17975(Var20.f_0, Var20.f_1, 1)) // Is item locked by packed bool
{
	Global_2359296[iVar47 /*5570*/].f_681.f_2308[iVar48] = 0;
}
```
This allows all the clothing items to be visible in the store, including GEN9 ones.
![1](https://github.com/user-attachments/assets/00daa479-93fe-437a-8b6f-9ef71819b463)
![2](https://github.com/user-attachments/assets/f3496958-bfb5-49e1-a383-e74e9282aca5)